### PR TITLE
Handle special characters in filenames for content disposition header.

### DIFF
--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -135,7 +135,7 @@ class GoogleDriveProvider(provider.BaseProvider):
             'trashed = false',
         ]
         if title:
-            queries.append("title = '{}'".format(title.replace('"', '\\"').replace('\'', '\\\'')))
+            queries.append("title = '{}'".format(title.replace("'", "\\'")))
         return ' and '.join(queries)
 
     @asyncio.coroutine

--- a/waterbutler/server/handlers/crud.py
+++ b/waterbutler/server/handlers/crud.py
@@ -64,16 +64,20 @@ class CRUDHandler(core.BaseHandler):
         except AttributeError:
             headers = {}
 
-        display_name = (
-            self.arguments.get('displayName') or
-            utils.parse_disposition_name(headers.get('content-disposition')) or
-            os.path.split(self.arguments['path'])[-1]
-        )
         self.set_header('Content-Type', result.content_type)
-
         if result.size:
             self.set_header('Content-Length', str(result.size))
-        self.set_header('Content-Disposition', 'attachment; filename=' + '"' + display_name + '"')
+
+        # Build `Content-Disposition` header from `displayName` override,
+        # headers of provider response, or file path, whichever is truthy first
+        if self.arguments.get('displayName'):
+            disposition = utils.make_disposition(self.arguments['displayName'])
+        elif headers.get('content-disposition'):
+            disposition = headers['content-disposition']
+        else:
+            disposition = utils.make_disposition(os.path.split(self.arguments['path'])[-1])
+
+        self.set_header('Content-Disposition', disposition)
 
         while True:
             chunk = yield from result.read(settings.CHUNK_SIZE)

--- a/waterbutler/server/utils.py
+++ b/waterbutler/server/utils.py
@@ -1,14 +1,11 @@
-import re
 import asyncio
 
-import tornado.concurrent
 import tornado.ioloop
+import tornado.concurrent
 
 
-def parse_disposition_name(disposition):
-    if disposition:
-        match = re.search(r'filename="(.*?)"', disposition)
-        return match.groups()[0] if match else None
+def make_disposition(filename):
+    return 'attachment;filename="{}"'.format(filename.replace('"', '\\"'))
 
 
 # Running Tornado on asyncio's event loop, including 'yield from' support in request handlers


### PR DESCRIPTION
Updates content-disposition header fix from @kushG to handle quotation marks in file names.
@chrisseto or @icereval, can you take a look?
